### PR TITLE
actuator: Removing actuator plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
## Whats changed

- Removing the spring actuator plugin, this causes a stack overflow error when deployed on GOV PaaS.